### PR TITLE
bumping dependency and adding exclusions to remove warnings

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -8,7 +8,7 @@
           :src-linenum-anchor-prefix "L"}
   :dependencies [[org.clojure/clojure "1.6.0"]
                  [org.pegdown/pegdown "1.4.2"]
-                 [com.googlecode.owasp-java-html-sanitizer/owasp-java-html-sanitizer "r223"]]
+                 [com.googlecode.owasp-java-html-sanitizer/owasp-java-html-sanitizer "r239" :exclusions [com.google.guava/guava com.google.code.findbugs/jsr305]]]
   :java-source-paths ["src/java"])
 
 


### PR DESCRIPTION
Like the tin says. I was getting annoyed with some warning the dependency was throwing, so this is a version bump plus some exclusions. Tests were failing before the version bump so it doesn't like it's causing a build fail. Still not completely sure if stuff got broken. Thoughts would be appreciated.